### PR TITLE
feat/ implementing automatic mail sender

### DIFF
--- a/src/services/mailer.js
+++ b/src/services/mailer.js
@@ -17,6 +17,10 @@ dotenv.config();
 export default async function mailer(config) {
     const { to, subject, text } = config
 
+    if(!to || to.trim() === '') throw 'config.to must be a valid string'
+    if(!subject || subject.trim() === '') throw 'config.subject must be a valid string'
+    if(!text || text.trim() === '') throw 'config.text must be a valid string'
+
     const oAuth2Client = new google.auth.OAuth2(
         process.env.CLIENT_ID,
         process.env.CLIENT_SECRET,

--- a/src/services/mailer.js
+++ b/src/services/mailer.js
@@ -53,11 +53,3 @@ export default async function mailer(config) {
         return e
     }
 }
-
-const response = await mailer({
-    to: 'yohanhxh@gmail.com',
-    subject: 'teste',
-    text: 'final texting'
-})
-
-console.log(response)

--- a/src/services/mailer.js
+++ b/src/services/mailer.js
@@ -1,0 +1,63 @@
+import nodemailer from 'nodemailer';
+import { google } from 'googleapis';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/** 
+ * Send a mail to one or more adresses
+ * @async
+ * @function
+ * @param {Object} config the configuration object
+ * @param {string | Array.<string>} to the mail's adressee or an array of adressees
+ * @param {string} subject the text sent into mail's subject field
+ * @param {string} text mail's content
+ * @return {Promise} resolves to the response object of nodemailer
+ */
+export default async function mailer(config) {
+    const { to, subject, text } = config
+
+    const oAuth2Client = new google.auth.OAuth2(
+        process.env.CLIENT_ID,
+        process.env.CLIENT_SECRET,
+        process.env.REDIRECT_URI
+    )
+    
+    oAuth2Client.setCredentials({ refresh_token: process.env.REFRESH_TOKEN })
+
+    try {
+        const accessToken = await oAuth2Client.getAccessToken()
+
+        const transport = nodemailer.createTransport({
+            service: 'gmail',
+            auth: {
+                type: 'OAuth2',
+                user: 'my.drugs.driven@gmail.com',
+                clientId: process.env.CLIENT_ID,
+                clientSecret: process.env.CLIENT_SECRET,
+                refreshToken: process.env.REFRESH_TOKEN,
+                accessToken: accessToken
+            }
+        })
+
+        const mailOptions = {
+            from: 'MyDrugs <my.drugs.driven@gmail.com>',
+            to,
+            subject,
+            text,
+        }
+
+        const result = await transport.sendMail(mailOptions)
+        return result
+    } catch(e) {
+        return e
+    }
+}
+
+const response = await mailer({
+    to: 'yohanhxh@gmail.com',
+    subject: 'teste',
+    text: 'final texting'
+})
+
+console.log(response)


### PR DESCRIPTION
This commit implements a mail feature in src/services/mailer.js

It is possible to send an email from 'my.drugs.driven@gmail.com' to any other address, just by providing the addresse, the text content and the subject. This feature works with the google apis services of authentication and requires four .env variables:

CLIENT_ID
CLIENT_SECRET
REDIRECT_URI
REFRESH_TOKEN

provided by the app dashboard on: https://console.cloud.google.com/home/dashboard?project=mydrugs-331516